### PR TITLE
Make error message available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ class HugeUploader {
 
             else {
                 if (this.paused || this.offline) return;
-                this._eventTarget.dispatchEvent(new CustomEvent('error', { detail: `Server responded with ${res.status}. Stopping upload` }));
+                this._eventTarget.dispatchEvent(new CustomEvent('error', { detail: res }));
             }
         })
         .catch((err) => {


### PR DESCRIPTION
Instead of forcing us to show same error message. It would be better to allow the server to provide that message.
I saw your example in `nodejs` version and there, your provide custom error message for each error, but in `client` side, you did not make use of that errors.