### PR TITLE
Correctly implements CustomEvent API.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ class HugeUploader {
                 if (++this.chunkCount < this.totalChunks) this._sendChunks();
                 else {
                   res.text().then(body => {
-                    this._eventTarget.dispatchEvent(new CustomEvent('finish', { body }));
+                    this._eventTarget.dispatchEvent(new CustomEvent('finish', { detail: body }));
                   })
                 }
 


### PR DESCRIPTION
The last response passed in the constructor of the 'finish' event has to be passed in a 'detail' key.

https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent

PS: Can you please create a release with last changes from master.